### PR TITLE
feat(shared): :sparkles: implements domain value objects (Money, Quantity, Uuid). Closes #35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ diesel-async = { version = "0.9.2", default-features = false, features = [
   "bb8",
   "async-connection-wrapper",
 ] }
+uuid = { version = "1.18.1", features = [
+  "v7",
+  "serde",
+], default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
@@ -62,7 +66,10 @@ serde = "1.0.226"
 base64 = "0.22.1"
 serde_json = "1.0.145"
 thiserror = "2.0.16"
-uuid = { version = "1.18.1", features = ["v7", "serde"] }
+uuid = { version = "1.18.1", features = [
+  "v7",
+  "serde",
+], default-features = false }
 log = "0.4.28"
 once_cell = "1.21.3"
 anyhow = "1.0.104"

--- a/crates/context/shared/Cargo.toml
+++ b/crates/context/shared/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+uuid.workspace = true
+anyhow.workspace = true
+rust_decimal = "1.43.0"
 
 [lints]
 workspace = true

--- a/crates/context/shared/src/errors.rs
+++ b/crates/context/shared/src/errors.rs
@@ -1,0 +1,5 @@
+use std::fmt::{Debug, Display};
+
+pub trait DomainError: Display + Debug + Send + Sync + 'static {
+    fn code(&self) -> &'static str;
+}

--- a/crates/context/shared/src/lib.rs
+++ b/crates/context/shared/src/lib.rs
@@ -1,1 +1,8 @@
+pub mod errors;
+pub mod money;
+pub mod quantity;
+pub mod uuid;
 
+pub use errors::DomainError;
+pub use quantity::{Quantity, QuantityError};
+pub use uuid::{Uuid, UuidError};

--- a/crates/context/shared/src/money.rs
+++ b/crates/context/shared/src/money.rs
@@ -1,0 +1,145 @@
+use std::{error, fmt};
+
+use rust_decimal::Decimal;
+
+use crate::DomainError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Currency {
+    Bob,
+    Usd,
+    Sol,
+    Brl,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MoneyError {
+    Negative { value: Decimal },
+    CurrencyMismatch { left: Currency, right: Currency },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Money {
+    value: Decimal,
+    currency: Currency,
+}
+
+impl Money {
+    pub fn new(value: Decimal, currency: Currency) -> Result<Self, MoneyError> {
+        Self::ensure_not_negative(value)?;
+
+        Ok(Self { value, currency })
+    }
+
+    pub fn signed(value: Decimal, currency: Currency) -> Self {
+        Self { value, currency }
+    }
+
+    pub fn value(&self) -> Decimal {
+        self.value
+    }
+
+    pub fn currency(&self) -> Currency {
+        self.currency
+    }
+
+    pub fn is_negative(&self) -> bool {
+        self.value.is_sign_negative()
+    }
+
+    pub fn add(&self, other: &Money) -> Result<Money, MoneyError> {
+        self.ensure_same_currency(other)?;
+
+        Ok(Money::signed(self.value + other.value, self.currency))
+    }
+
+    pub fn sub(&self, other: &Money) -> Result<Money, MoneyError> {
+        self.ensure_same_currency(other)?;
+
+        Ok(Money::signed(self.value - other.value, self.currency))
+    }
+
+    fn ensure_not_negative(value: Decimal) -> Result<(), MoneyError> {
+        if value.is_sign_negative() {
+            return Err(MoneyError::Negative { value });
+        }
+        Ok(())
+    }
+
+    fn ensure_same_currency(&self, other: &Money) -> Result<(), MoneyError> {
+        if self.currency != other.currency {
+            return Err(MoneyError::CurrencyMismatch {
+                left: self.currency,
+                right: other.currency,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for MoneyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Negative { value } => write!(f, "Money must not be negative: {}", value),
+            Self::CurrencyMismatch { left, right } => {
+                write!(f, "Currency mismatch: {:?} vs {:?}", left, right)
+            }
+        }
+    }
+}
+
+impl error::Error for MoneyError {}
+
+impl DomainError for MoneyError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Negative { .. } => "money is negative",
+            Self::CurrencyMismatch { .. } => "money currency mismatch",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dec(raw: &str) -> Decimal {
+        raw.parse().unwrap()
+    }
+
+    #[test]
+    fn new_rejects_negative() {
+        let result = Money::new(dec("-1"), Currency::Bob);
+
+        assert_eq!(result, Err(MoneyError::Negative { value: dec("-1") }));
+    }
+
+    #[test]
+    fn new_accepts_zero_and_positive() {
+        assert!(Money::new(dec("0"), Currency::Bob).is_ok());
+        assert!(Money::new(dec("10.50"), Currency::Bob).is_ok());
+    }
+
+    #[test]
+    fn signed_allows_negative() {
+        let diff = Money::signed(dec("-5"), Currency::Bob);
+
+        assert!(diff.is_negative());
+    }
+
+    #[test]
+    fn decimal_sum_is_exact() {
+        let a = Money::new(dec("0.1"), Currency::Bob).unwrap();
+        let b = Money::new(dec("0.2"), Currency::Bob).unwrap();
+
+        assert_eq!(a.add(&b).unwrap().value(), dec("0.3"));
+    }
+
+    #[test]
+    fn add_rejects_currency_mismatch() {
+        let a = Money::new(dec("1"), Currency::Bob).unwrap();
+        let b = Money::new(dec("1"), Currency::Usd).unwrap();
+
+        assert!(a.add(&b).is_err());
+    }
+}

--- a/crates/context/shared/src/quantity.rs
+++ b/crates/context/shared/src/quantity.rs
@@ -1,0 +1,75 @@
+use std::{error, fmt};
+
+use crate::DomainError;
+
+pub struct Quantity {
+    value: i32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum QuantityError {
+    Negative { quantity: i32 },
+}
+
+impl Quantity {
+    pub fn new(value: i32) -> Result<Self, QuantityError> {
+        Self::ensure_is_positive(value)?;
+
+        Ok(Self { value })
+    }
+
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+
+    fn ensure_is_positive(value: i32) -> Result<(), QuantityError> {
+        if value <= 0 {
+            return Err(QuantityError::Negative { quantity: value });
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for QuantityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Negative { quantity } => write!(f, "Negative quantity: {}", quantity),
+        }
+    }
+}
+
+impl error::Error for QuantityError {}
+
+impl DomainError for QuantityError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Negative { .. } => "QUANTITY::NEGATIVE",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantity_not_allowed_zeros() {
+        let result = Quantity::new(0);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quantity_not_allowed_negatives() {
+        let result = Quantity::new(-1);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn quantity_is_valid_value() {
+        let result = Quantity::new(1);
+
+        assert!(result.is_ok());
+    }
+}

--- a/crates/context/shared/src/uuid.rs
+++ b/crates/context/shared/src/uuid.rs
@@ -1,0 +1,90 @@
+use std::fmt;
+
+use uuid::{Uuid as UuidValue, Version};
+
+use crate::DomainError;
+
+pub struct Uuid {
+    val: UuidValue,
+}
+
+#[derive(Debug)]
+pub enum UuidError {
+    Invalid,
+    IsNotV7,
+}
+
+impl Uuid {
+    pub fn from(uuid: &str) -> Result<Self, UuidError> {
+        let uuid_parsed = Self::ensure_is_valid(uuid)?;
+        Self::ensure_is_v7(uuid)?;
+
+        Ok(Self { val: uuid_parsed })
+    }
+
+    pub fn value(&self) -> UuidValue {
+        self.val
+    }
+
+    fn ensure_is_valid(value: &str) -> Result<UuidValue, UuidError> {
+        let uuid = UuidValue::parse_str(value).map_err(|_| UuidError::Invalid)?;
+
+        Ok(uuid)
+    }
+
+    fn ensure_is_v7(value: &str) -> Result<(), UuidError> {
+        let uuid = Self::ensure_is_valid(value)?;
+
+        if uuid.get_version() != Some(Version::SortRand) {
+            return Err(UuidError::IsNotV7);
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for UuidError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid => write!(f, "Uuid is invalid"),
+            Self::IsNotV7 => write!(f, "Uuid is not V7"),
+        }
+    }
+}
+
+impl std::error::Error for UuidError {}
+
+impl DomainError for UuidError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::IsNotV7 => "UUID::IS_NOT_V7",
+            UuidError::Invalid => "UUID::INVALID",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_is_not_valid() {
+        let result = Uuid::from("7fc275ab-5a08-4582-a4d2-4836743");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn uuid_is_not_v7() {
+        let result = Uuid::from("7fc275ab-5a08-4582-a4d2-4ccaaf836743");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn uuid_is_valid() {
+        let result = Uuid::from("01a0688f-6fd1-74e7-a842-b880ff8cca39");
+
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
 Closes #48 
 Closes #49 
 Closes #50
 
When the frontend needs to send a RequestId, we use the UUID value object. Is this more secure than sending something else